### PR TITLE
Create switch button

### DIFF
--- a/DeconzConfig/module.php
+++ b/DeconzConfig/module.php
@@ -110,7 +110,8 @@
 							"moduleID" => "{60F3A8DF-5953-4B9E-CB5A-EF7769E3C9FA}",
 							"configuration" => [
 								"DeviceID" => $item->uniqueid,
-								"DeviceType" => $type
+								"DeviceType" => $type,
+								'DetailType'   => $item->type
 							]
 						]
 					];

--- a/DeconzConfig/module.php
+++ b/DeconzConfig/module.php
@@ -111,7 +111,7 @@
 							"configuration" => [
 								"DeviceID" => $item->uniqueid,
 								"DeviceType" => $type,
-								'DetailType'   => $item->type
+								"DetailType"   => $item->type
 							]
 						]
 					];

--- a/DeconzConfig/module.php
+++ b/DeconzConfig/module.php
@@ -111,7 +111,7 @@
 							"configuration" => [
 								"DeviceID" => $item->uniqueid,
 								"DeviceType" => $type,
-								"DetailType"   => $item->type
+								"DetailType" => $item->type
 							]
 						]
 					];

--- a/DeconzGateway/module.php
+++ b/DeconzGateway/module.php
@@ -826,7 +826,7 @@ class DeconzGateway extends IPSModule
 						$whitelist = $config->whitelist;
 						$key	= $this->ReadAttributeString("ApiKey");
 						foreach($whitelist as $ApiKey => $item){
-							if($item->name == "ips" && $ApiKey <> $key){
+							if($item->name == "ips_test" && $ApiKey <> $key){
 								$Buffer['command'] = 'config/whitelist/'.$ApiKey;
 								$Buffer['method'] = 'DELETE';
 								$Buffer['data'] = '';

--- a/Light/module.php
+++ b/Light/module.php
@@ -66,14 +66,6 @@ class Z2DLightSwitch extends IPSModule
 				}
 			}
 		}else{
-			if($this->GetBuffer("Microtimer")<>""){
-				list($usec, $sec) = explode(" ", $this->GetBuffer("Microtimer"));
-				$last = (float)$usec + (float)$sec; 
-				list($usec, $sec) = explode(" ", microtime());
-				$now = (float)$usec + (float)$sec; 
-				if($now - $last < 0.25) return;
-			}
-			$this->SetBuffer("Microtimer", microtime());
 		    $this->SendDebug('Received', $Buffer, 0);
 
 		    if (property_exists($data, 'state')) {

--- a/README.md
+++ b/README.md
@@ -104,6 +104,22 @@
 		<td>Fix: SetSensitivity<br>
 			Neu: Vibrationstrength, Tiltangle, Orientation</td>
 	  </tr>
+	  <tr>
+		<td>V1.19</td>
+		<td>Fix: SetHeatpoint, SetOffset<br>
+			Neu: Valve-Position</td>
+	  </tr>
+	  <tr>
+		<td>V1.20</td>
+		<td>Fix: Variablentyp SetConfig</td>
+	  </tr>
+	  <tr>
+		<td>V1.21</td>
+		<td>Fix: Probleme ab DeCONZ-Version 2.05.79<br>
+			Fix: Variablentyp SetSensitivity/SetOffset<br>
+			Fix: Teilweise fehlendes Profil Sensitivity<br>
+			Fix: Batteriestatus für Ikea Kadrilj</td>
+	  </tr>
 	</table>
   </body>
 </html>

--- a/Sensor/README.md
+++ b/Sensor/README.md
@@ -34,6 +34,16 @@
 			Der Erfolg der Änderung wird im Debugfenster angezeigt<br>
 			Alternativ kann mit <i>Z2D_GetConfig($ID)</i> geprüft werden, ob die Änderung erfolgreich war</td>
 	  </tr>
+	  <tr>
+		<td>4.</td>
+		<td><b><i>Z2D_setSensitivity($ID, $value)</i></b></td>
+		<td>Einstellen der Sensor-Empfindlichkeit</td>
+	  </tr>
+	  <tr>
+		<td>5.</td>
+		<td><b><i>Z2D_setOffset($ID, $value)</i></b></td>
+		<td>Einstellen des Temperatur-Offsets z.B. bei Aqara Temperatursensoren</td>
+	  </tr>
 	</table>
   </body>
 </html>

--- a/Sensor/form.json
+++ b/Sensor/form.json
@@ -3,7 +3,7 @@
     [
     { "name": "DeviceID", "type": "ValidationTextBox", "caption": "DeviceID:" },
     { "name": "DetailType", "type": "ValidationTextBox", "caption": "Detail Type:", "enabled": false },
-    { "type": "CheckBox", "name": "CreateSwitchButton", "caption": "Create Switch Button", "visible": ""}
+    { "type": "CheckBox", "name": "CreateSwitchButton", "caption": "Create Switch Button"}
     ],
     "status":
     [

--- a/Sensor/form.json
+++ b/Sensor/form.json
@@ -2,7 +2,7 @@
     "elements":
     [
     { "name": "DeviceID", "type": "ValidationTextBox", "caption": "DeviceID:" },
-    { "name": "DeviceType", "type": "ValidationTextBox", "caption": "Device Type:", "enabled": false },
+    { "name": "DetailType", "type": "ValidationTextBox", "caption": "Detail Type:", "enabled": false },
     { "type": "CheckBox", "name": "CreateSwitchButton", "caption": "Create Switch Button", "visible": ""}
     ],
     "status":

--- a/Sensor/form.json
+++ b/Sensor/form.json
@@ -2,8 +2,8 @@
     "elements":
     [
     { "name": "DeviceID", "type": "ValidationTextBox", "caption": "DeviceID:" },
-    { "name": "DetailType", "type": "ValidationTextBox", "caption": "Detail Type:", "enabled": false },
-    { "type": "CheckBox", "name": "CreateSwitchButton", "caption": "Create Switch Button"}
+    { "name": "DetailType", "type": "ValidationTextBox", "caption": "Type:", "enabled": false },
+    { "type": "CheckBox", "name": "CreateSwitchButton", "caption": "Create Switch Buttons"}
     ],
     "status":
     [

--- a/Sensor/form.json
+++ b/Sensor/form.json
@@ -1,7 +1,9 @@
 {
     "elements":
     [
-		{ "name": "DeviceID", "type": "ValidationTextBox", "caption": "DeviceID:" }
+    { "name": "DeviceID", "type": "ValidationTextBox", "caption": "DeviceID:" },
+    { "name": "DeviceType", "type": "ValidationTextBox", "caption": "Device Type:", "enabled": false },
+    { "type": "CheckBox", "name": "CreateSwitchButton", "caption": "Create Switch Button", "visible": ""}
     ],
     "status":
     [

--- a/Sensor/locale.json
+++ b/Sensor/locale.json
@@ -50,6 +50,7 @@
       "Sensitivity": "Empfindlichkeit",
       "Event": "Ereignis",
       "Occupied Delay": "Verzögerung Anwesenheit Aus",
+      "Create Switch Button": "Einzelne Schalterknöpfe erstellen",
 	  "Device unreachable": "Gerät nicht erreichbar"
     }
   }

--- a/Sensor/locale.json
+++ b/Sensor/locale.json
@@ -49,6 +49,7 @@
       "Orientation": "Orientierung",
       "Sensitivity": "Empfindlichkeit",
       "Event": "Ereignis",
+      "Occupied Delay": "Verzögerung Anwesenheit",
 	  "Device unreachable": "Gerät nicht erreichbar"
     }
   }

--- a/Sensor/locale.json
+++ b/Sensor/locale.json
@@ -50,7 +50,8 @@
       "Sensitivity": "Empfindlichkeit",
       "Event": "Ereignis",
       "Occupied Delay": "Verzögerung Anwesenheit Aus",
-      "Create Switch Button": "Einzelne Schalterknöpfe erstellen",
+      "Create Switch Buttons": "Einzelne Schalterknöpfe erstellen",
+      "Type": "Typ",
 	  "Device unreachable": "Gerät nicht erreichbar"
     }
   }

--- a/Sensor/locale.json
+++ b/Sensor/locale.json
@@ -49,7 +49,7 @@
       "Orientation": "Orientierung",
       "Sensitivity": "Empfindlichkeit",
       "Event": "Ereignis",
-      "Occupied Delay": "Verzögerung Anwesenheit",
+      "Occupied Delay": "Verzögerung Anwesenheit Aus",
 	  "Device unreachable": "Gerät nicht erreichbar"
     }
   }

--- a/Sensor/module.php
+++ b/Sensor/module.php
@@ -14,7 +14,8 @@ class Z2DSensor extends IPSModule
         $this->ConnectParent('{9013F138-F270-C396-09D6-43368E390C5F}');
 
         $this->RegisterPropertyString('DeviceID', "");
-        $this->RegisterPropertyString('DeviceType', "sensors");
+		$this->RegisterPropertyString('DeviceType', "sensors");
+		$this->RegisterPropertyBoolean("CreateSwitchButton", true);
 #	-----------------------------------------------------------------------------------
         $this->RegisterAttributeInteger("State", 0);
         $this->RegisterAttributeInteger("LastUpdated", 0);
@@ -72,28 +73,31 @@ class Z2DSensor extends IPSModule
 				if (property_exists($Payload, 'buttonevent')) {
 					$this->RegisterVariableInteger('Z2D_Event', $this->Translate('Event'), '');
 					$this->SetValue('Z2D_Event', $Payload->buttonevent);
+					if($this->ReadPropertyBoolean("CreateSingleButton")) {
+						$button = (int)($Payload->buttonevent / 1000);
+						$buttonident = (string)$button;
+						$buttonident = preg_replace ( '/[^a-z0-9]/i', 'minus', $buttonident );
+						$state  = $Payload->buttonevent % 1000;
 
-					$button = (int)($Payload->buttonevent / 1000);
-					$state  = $Payload->buttonevent % 1000;
+						if (!IPS_VariableProfileExists('ButtonEvent.Z2D')) {
+							IPS_CreateVariableProfile('ButtonEvent.Z2D', 1);
+							IPS_SetVariableProfileIcon('ButtonEvent.Z2D', 'Power');
+							IPS_SetVariableProfileAssociation('ButtonEvent.Z2D', 0, $this->Translate('Initial Press'), '',-1);
+							IPS_SetVariableProfileAssociation('ButtonEvent.Z2D', 1, $this->Translate('Hold'), '',-1);
+							IPS_SetVariableProfileAssociation('ButtonEvent.Z2D', 2, $this->Translate('Release after press'), '',-1);
+							IPS_SetVariableProfileAssociation('ButtonEvent.Z2D', 3, $this->Translate('Release after hold'), '',-1);
+							IPS_SetVariableProfileAssociation('ButtonEvent.Z2D', 4, $this->Translate('Double press'), '',-1);
+							IPS_SetVariableProfileAssociation('ButtonEvent.Z2D', 5, $this->Translate('Triple press'), '',-1);
+							IPS_SetVariableProfileAssociation('ButtonEvent.Z2D', 6, $this->Translate('Quadruple press'), '',-1);
+							IPS_SetVariableProfileAssociation('ButtonEvent.Z2D', 7, $this->Translate('Shake'), '',-1);
+							IPS_SetVariableProfileAssociation('ButtonEvent.Z2D', 8, $this->Translate('Drop'), '',-1);
+							IPS_SetVariableProfileAssociation('ButtonEvent.Z2D', 9, $this->Translate('Tilt'), '',-1);
+							IPS_SetVariableProfileAssociation('ButtonEvent.Z2D',10, $this->Translate('Many press'), '',-1);
+						}
 
-					if (!IPS_VariableProfileExists('ButtonEvent.Z2D')) {
-						IPS_CreateVariableProfile('ButtonEvent.Z2D', 1);
-						IPS_SetVariableProfileIcon('ButtonEvent.Z2D', 'Power');
-						IPS_SetVariableProfileAssociation('ButtonEvent.Z2D', 0, $this->Translate('Initial Press'), '',-1);
-						IPS_SetVariableProfileAssociation('ButtonEvent.Z2D', 1, $this->Translate('Hold'), '',-1);
-						IPS_SetVariableProfileAssociation('ButtonEvent.Z2D', 2, $this->Translate('Release after press'), '',-1);
-						IPS_SetVariableProfileAssociation('ButtonEvent.Z2D', 3, $this->Translate('Release after hold'), '',-1);
-						IPS_SetVariableProfileAssociation('ButtonEvent.Z2D', 4, $this->Translate('Double press'), '',-1);
-						IPS_SetVariableProfileAssociation('ButtonEvent.Z2D', 5, $this->Translate('Triple press'), '',-1);
-						IPS_SetVariableProfileAssociation('ButtonEvent.Z2D', 6, $this->Translate('Quadruple press'), '',-1);
-						IPS_SetVariableProfileAssociation('ButtonEvent.Z2D', 7, $this->Translate('Shake'), '',-1);
-						IPS_SetVariableProfileAssociation('ButtonEvent.Z2D', 8, $this->Translate('Drop'), '',-1);
-						IPS_SetVariableProfileAssociation('ButtonEvent.Z2D', 9, $this->Translate('Tilt'), '',-1);
-						IPS_SetVariableProfileAssociation('ButtonEvent.Z2D',10, $this->Translate('Many press'), '',-1);
+						$this->RegisterVariableInteger('Z2D_Button_'.$buttonident, $this->Translate('Button')." ".$button, 'ButtonEvent.Z2D');
+						SetValue($this->GetIDForIdent('Z2D_Button_'.$buttonident), $state);
 					}
-
-					$this->RegisterVariableInteger('Z2D_Button_'.$button, $this->Translate('Button')." ".$button, 'ButtonEvent.Z2D');
-					SetValue($this->GetIDForIdent('Z2D_Button_'.$button), $state);
 				}
 				if (property_exists($Payload, 'carbonmonoxide')) {
 					$this->RegisterVariableBoolean('Z2D_Carbonmonoxide', $this->Translate('Carbonmonoxide'), '~Alert');

--- a/Sensor/module.php
+++ b/Sensor/module.php
@@ -248,7 +248,13 @@ class Z2DSensor extends IPSModule
 			    SetValue($this->GetIDForIdent('Z2D_offset'), $Payload->offset / 100.0);
 			}
 			if (property_exists($Payload, 'delay')) {
-			    $this->RegisterVariableInteger('Z2D_delay', $this->Translate('Delay'), '~Intensity.65535');
+				if (!IPS_VariableProfileExists('Delay.Z2D')) {
+					IPS_CreateVariableProfile('Delay.Z2D', 1);
+					IPS_SetVariableProfileIcon('Delay.Z2D','Hourglass');
+					IPS_SetVariableProfileText('Delay.Z2D', '', 's');
+					IPS_SetVariableProfileValues('Delay.Z2D', 0, 65535, 0);
+				}
+			    $this->RegisterVariableInteger('Z2D_delay', $this->Translate('Delay'), 'Delay.Z2D');
 	            $this->EnableAction('Z2D_delay');
 			    SetValue($this->GetIDForIdent('Z2D_delay'), $Payload->delay);
 			}

--- a/Sensor/module.php
+++ b/Sensor/module.php
@@ -252,7 +252,7 @@ class Z2DSensor extends IPSModule
 					IPS_CreateVariableProfile('Delay.Z2D', 1);
 					IPS_SetVariableProfileIcon('Delay.Z2D','Hourglass');
 					IPS_SetVariableProfileText('Delay.Z2D', '', 's');
-					IPS_SetVariableProfileValues('Delay.Z2D', 0, 65535, 0);
+					IPS_SetVariableProfileValues('Delay.Z2D', 0, 65535, 1);
 				}
 			    $this->RegisterVariableInteger('Z2D_delay', $this->Translate('Occupied Delay'), 'Delay.Z2D');
 	            $this->EnableAction('Z2D_delay');

--- a/Sensor/module.php
+++ b/Sensor/module.php
@@ -254,7 +254,7 @@ class Z2DSensor extends IPSModule
 					IPS_SetVariableProfileText('Delay.Z2D', '', 's');
 					IPS_SetVariableProfileValues('Delay.Z2D', 0, 65535, 0);
 				}
-			    $this->RegisterVariableInteger('Z2D_delay', $this->Translate('Delay'), 'Delay.Z2D');
+			    $this->RegisterVariableInteger('Z2D_delay', $this->Translate('Occupied Delay'), 'Delay.Z2D');
 	            $this->EnableAction('Z2D_delay');
 			    SetValue($this->GetIDForIdent('Z2D_delay'), $Payload->delay);
 			}

--- a/Sensor/module.php
+++ b/Sensor/module.php
@@ -77,7 +77,8 @@ class Z2DSensor extends IPSModule
 					if($this->ReadPropertyBoolean("CreateSwitchButton")) {
 						$button = (int)($Payload->buttonevent / 1000);
 						$buttonident = (string)$button;
-						$buttonident = preg_replace ( '/[^a-z0-9]/i', 'minus', $buttonident );
+						$buttonident = preg_replace ( '/[^a-z0-9]/i', '_', $buttonident ); // replace all unsupported IDENT character with _
+						
 						$state  = $Payload->buttonevent % 1000;
 
 						if (!IPS_VariableProfileExists('ButtonEvent.Z2D')) {

--- a/Sensor/module.php
+++ b/Sensor/module.php
@@ -74,7 +74,7 @@ class Z2DSensor extends IPSModule
 				if (property_exists($Payload, 'buttonevent')) {
 					$this->RegisterVariableInteger('Z2D_Event', $this->Translate('Event'), '');
 					$this->SetValue('Z2D_Event', $Payload->buttonevent);
-					if($this->ReadPropertyBoolean("CreateSingleButton")) {
+					if($this->ReadPropertyBoolean("CreateSwitchButton")) {
 						$button = (int)($Payload->buttonevent / 1000);
 						$buttonident = (string)$button;
 						$buttonident = preg_replace ( '/[^a-z0-9]/i', 'minus', $buttonident );

--- a/Sensor/module.php
+++ b/Sensor/module.php
@@ -213,6 +213,10 @@ class Z2DSensor extends IPSModule
 						if($this->ReadAttributeInteger("State") <> 215)$this->WriteAttributeInteger("State", 215);
 					}
 				}
+				if (property_exists($Payload, 'battery')) {
+					$this->RegisterVariableInteger('Z2D_Battery', $this->Translate('Battery'), '~Battery.100');
+					SetValue($this->GetIDForIdent('Z2D_Battery'), $Payload->battery);
+				}
 			}
 		}
 

--- a/Sensor/module.php
+++ b/Sensor/module.php
@@ -15,6 +15,7 @@ class Z2DSensor extends IPSModule
 
         $this->RegisterPropertyString('DeviceID', "");
 		$this->RegisterPropertyString('DeviceType', "sensors");
+		$this->RegisterPropertyString('DetailType',"");
 		$this->RegisterPropertyBoolean("CreateSwitchButton", true);
 #	-----------------------------------------------------------------------------------
         $this->RegisterAttributeInteger("State", 0);

--- a/Sensor/module.php
+++ b/Sensor/module.php
@@ -190,7 +190,7 @@ class Z2DSensor extends IPSModule
 					$this->RegisterVariableFloat('Z2D_voltage', $this->Translate('Voltage'), '~Volt');
 					SetValue($this->GetIDForIdent('Z2D_voltage'), $Payload->voltage);
 				}
-				if (property_exists($Payload, 'valve')) { // 27.06.2020 Attain new: Thermostat valve
+				if (property_exists($Payload, 'valve')) { 
 					$this->RegisterVariableInteger('Z2D_valve', $this->Translate('Valve'), '~Intensity.255'); 
 					SetValue($this->GetIDForIdent('Z2D_valve'), $Payload->valve);
 				}
@@ -251,11 +251,6 @@ class Z2DSensor extends IPSModule
 			    $this->RegisterVariableInteger('Z2D_sensitivitymax', 'max. '.$this->Translate('Sensitivity'), '');
 			    $this->SetValue('Z2D_sensitivitymax', $Payload->sensitivitymax);
 			}
-			if (property_exists($Payload, 'locked')) {
-				$this->RegisterVariableBoolean('Z2D_locked', $this->Translate('Locked'), '~Lock');
-				$this->EnableAction('Z2D_locked');
-			    $this->SetValue('Z2D_locked', $Payload->locked);
-			}
 			if (property_exists($Payload, 'sensitivity')) {
 				if (!IPS_VariableProfileExists('Sensitivity.Z2D')) {
 					IPS_CreateVariableProfile('Sensitivity.Z2D', 1);
@@ -263,7 +258,15 @@ class Z2DSensor extends IPSModule
 					IPS_SetVariableProfileAssociation('Sensitivity.Z2D', 1, $this->Translate('Medium'), '',-1);
 					IPS_SetVariableProfileAssociation('Sensitivity.Z2D', 2, $this->Translate('High'), '',-1);
 				}
-				$this->RegisterVariableInteger('Z2D_sensitivity', $this->Translate('Sensitivity'), 'Sensitivity.Z2D');
+				if (property_exists($Payload, 'sensitivitymax')) {
+					if ($Payload->sensitivitymax == 2) {
+						$this->RegisterVariableInteger('Z2D_sensitivity', $this->Translate('Sensitivity'), 'Sensitivity.Z2D');
+					}else{
+						$this->RegisterVariableInteger('Z2D_sensitivity', $this->Translate('Sensitivity'), '');
+					}
+				}else{
+					$this->RegisterVariableInteger('Z2D_sensitivity', $this->Translate('Sensitivity'), 'Sensitivity.Z2D');
+				}
 				$this->EnableAction('Z2D_sensitivity');
 			    $this->SetValue('Z2D_sensitivity', $Payload->sensitivity);
 			}

--- a/Sensor/module.php
+++ b/Sensor/module.php
@@ -251,18 +251,19 @@ class Z2DSensor extends IPSModule
 			    $this->RegisterVariableInteger('Z2D_sensitivitymax', 'max. '.$this->Translate('Sensitivity'), '');
 			    $this->SetValue('Z2D_sensitivitymax', $Payload->sensitivitymax);
 			}
+			if (property_exists($Payload, 'locked')) {
+				$this->RegisterVariableBoolean('Z2D_locked', $this->Translate('Locked'), '~Lock');
+				$this->EnableAction('Z2D_locked');
+			    $this->SetValue('Z2D_locked', $Payload->locked);
+			}
 			if (property_exists($Payload, 'sensitivity')) {
-				if (!property_exists($Payload, 'sensitivitymax')) {
-					if (!IPS_VariableProfileExists('Sensitivity.Z2D')) {
-						IPS_CreateVariableProfile('Sensitivity.Z2D', 1);
-						IPS_SetVariableProfileAssociation('Sensitivity.Z2D', 0, $this->Translate('Low'), '',-1);
-						IPS_SetVariableProfileAssociation('Sensitivity.Z2D', 1, $this->Translate('Medium'), '',-1);
-						IPS_SetVariableProfileAssociation('Sensitivity.Z2D', 2, $this->Translate('High'), '',-1);
-					}
-					$this->RegisterVariableInteger('Z2D_sensitivity', $this->Translate('Sensitivity'), 'Sensitivity.Z2D');
-				}else{
-					$this->RegisterVariableInteger('Z2D_sensitivity', $this->Translate('Sensitivity'), '');
+				if (!IPS_VariableProfileExists('Sensitivity.Z2D')) {
+					IPS_CreateVariableProfile('Sensitivity.Z2D', 1);
+					IPS_SetVariableProfileAssociation('Sensitivity.Z2D', 0, $this->Translate('Low'), '',-1);
+					IPS_SetVariableProfileAssociation('Sensitivity.Z2D', 1, $this->Translate('Medium'), '',-1);
+					IPS_SetVariableProfileAssociation('Sensitivity.Z2D', 2, $this->Translate('High'), '',-1);
 				}
+				$this->RegisterVariableInteger('Z2D_sensitivity', $this->Translate('Sensitivity'), 'Sensitivity.Z2D');
 				$this->EnableAction('Z2D_sensitivity');
 			    $this->SetValue('Z2D_sensitivity', $Payload->sensitivity);
 			}

--- a/Sensor/module.php
+++ b/Sensor/module.php
@@ -247,6 +247,11 @@ class Z2DSensor extends IPSModule
 	            $this->EnableAction('Z2D_offset');
 			    SetValue($this->GetIDForIdent('Z2D_offset'), $Payload->offset / 100.0);
 			}
+			if (property_exists($Payload, 'delay')) {
+			    $this->RegisterVariableInteger('Z2D_delay', $this->Translate('Delay'), '~Intensity.65535');
+	            $this->EnableAction('Z2D_delay');
+			    SetValue($this->GetIDForIdent('Z2D_delay'), $Payload->delay);
+			}
 			if (property_exists($Payload, 'sensitivitymax')) {
 			    $this->RegisterVariableInteger('Z2D_sensitivitymax', 'max. '.$this->Translate('Sensitivity'), '');
 			    $this->SetValue('Z2D_sensitivitymax', $Payload->sensitivitymax);

--- a/library.json
+++ b/library.json
@@ -3,7 +3,7 @@
 	"author": "Silberstreifen",
 	"name": "Zigbee2DeCONZ",
 	"url": "",
-	"version": "1.18",
+	"version": "1.21",
 	"build": 0,
 	"date": 0
 }

--- a/libs/Zigbee2DeCONZHelper.php
+++ b/libs/Zigbee2DeCONZHelper.php
@@ -223,10 +223,8 @@ trait Zigbee2DeCONZHelper
     {
         if($value <  6)$value =  6;
         if($value > 30)$value = 30;
-		$this->SetValue('Z2D_heatsetpoint',$value);	// 27.06.2020 bugfix: remove if($this->ReadPropertyBoolean("Status")), does not exist for sensors
-		$data['heatsetpoint'] = $value * 100;
-		$this->SetDeconz('config', json_encode($data));	// 27.06.2020 bugfix: change from state to config 
-		$this->GetStateDeconz();						// 27.05.2020 request config after send 
+		$this->SetValue('Z2D_heatsetpoint',$value);
+		$this->SetConfig('heatsetpoint', (string) ($value * 100));
     }    
 
     public function setSensitivity(int $value)
@@ -247,14 +245,15 @@ trait Zigbee2DeCONZHelper
     {
         if($value < -5) $value = -5;
         if($value >  5) $value =  5;
-			$this->SetValue('Z2D_offset',$value);	// 27.06.2020 bugfix: remove if($this->ReadPropertyBoolean("Status")), does not exist for sensors
-		$data['offset'] = $value*100;
-		$this->SetDeconz('config', json_encode($data));
-		$this->GetStateDeconz();			// 27.05.2020 request config after send 
+		$this->SetValue('Z2D_offset',$value);
+		$this->SetConfig('offset', (string) ($value * 100));
     }
 
-    public function SetConfig(string $parameter, $value)
+    public function SetConfig(string $parameter, string $value)
     {
+        if(is_numeric(str_replace(",",".", $value))){
+            $value = (float)str_replace(",",".", $value);
+        }
 		$data[$parameter] = $value;
         $this->SetDeconz('config', json_encode($data));
 		$this->GetStateDeconz();
@@ -411,4 +410,3 @@ trait Zigbee2DeCONZHelper
         return $dec;
     }
 }
-

--- a/libs/Zigbee2DeCONZHelper.php
+++ b/libs/Zigbee2DeCONZHelper.php
@@ -32,6 +32,9 @@ trait Zigbee2DeCONZHelper
             case 'Z2D_offset':
                 $this->setOffset($Value);
                 break;
+                case 'Z2D_delay':
+                    $this->setDelay($Value);
+                    break;
             case 'Z2D_sensitivity':
                 $this->setSensitivity($Value);
                 break;
@@ -247,6 +250,12 @@ trait Zigbee2DeCONZHelper
         if($value >  5) $value =  5;
 		$this->SetValue('Z2D_offset',$value);
 		$this->SetConfig('offset', (string) ($value * 100));
+    }
+
+    public function setDelay(int $value)
+    {
+		$this->SetValue('Z2D_delay',$value);
+		$this->SetConfig('delay', (string) ($value));
     }
 
     public function SetConfig(string $parameter, string $value)

--- a/libs/Zigbee2DeCONZHelper.php
+++ b/libs/Zigbee2DeCONZHelper.php
@@ -234,7 +234,7 @@ trait Zigbee2DeCONZHelper
 		    if($value > 2) $value = 2;
 		}else{
 			$max = $this->GetValue('Z2D_sensitivitymax');
-		    if($value < 1) $value = 1;
+		    if($value < 0) $value = 0;
 		    if($value > $max) $value = $max;
 		}
 		$data['sensitivity'] = $value;


### PR DESCRIPTION
Hallo Jürgen,

wie im Forum angesprochen, folgende Änderungen:
1. fix: Anlegen von Switchvariablen schlug fehl bei negativen Werten. Der IDENT darf kein "-" Zeichen enthalten.
$buttonident = preg_replace ( '/[^a-z0-9]/i', '_', $buttonident ); // replace all unsupported IDENT character with _

2. Ich habe in die sensor instanz eine Checkbox hinzugefügt. Ist die Aus, werden keine Schaltervariablen angelegt.
Diese Checkbox macht nur bei Schaltern einen Sinn und verwirrt bei allen anderen "Sensoren". Deswegen sollte dieser nur sichtbar sein, wenn "Detail Type" == ZHASwitch ist. Deswegen übergebe ich den nun beim erstellen der Instanz.
Wie man jetzt die Checkbox dynamisch "visible" setzt (oder nicht) habe ich noch nicht kapiert. Das überlasse ich deshalb mal Dir :-)
![ZHASwitch](https://user-images.githubusercontent.com/35669489/91222249-322c7c00-e71f-11ea-921b-b8053ca99bed.png)