### PR TITLE
Set debounce to fix 30ms (was upto 1s).

### DIFF
--- a/Group/module.php
+++ b/Group/module.php
@@ -19,7 +19,7 @@ class Z2DGroup extends IPSModule
 #	-----------------------------------------------------------------------------------
 		$this->RegisterAttributeString('CommandList', "");
 		$this->RegisterAttributeString('GroupLights', "");
-		$this->RegisterAttributeInteger("LastUpdated", 0);
+		$this->RegisterAttributeFloat("LastUpdated", 0);
     }
 
 

--- a/libs/DeconzBaseModule.php
+++ b/libs/DeconzBaseModule.php
@@ -159,7 +159,6 @@ trait DeconzBaseModule
 				$update = true;
 				if (property_exists($Payload, 'lastupdated')) {
 					$ts = $this->timestampWithMillis($Payload->lastupdated);
-					IPS_LogMessage("deconz", $ts . " - 0-03 > " . $this->ReadAttributeFloat("LastUpdated") . " = " . ($ts - 0.03 > $this->ReadAttributeFloat("LastUpdated")));
 					if($ts - 0.03 > $this->ReadAttributeFloat("LastUpdated")) {
 						$this->WriteAttributeFloat("LastUpdated", $ts);
 					}else{

--- a/libs/DeconzBaseModule.php
+++ b/libs/DeconzBaseModule.php
@@ -158,8 +158,12 @@ trait DeconzBaseModule
 	
 				$update = true;
 				if (property_exists($Payload, 'lastupdated')) {
-					if(strtotime($Payload->lastupdated." UTC") <> $this->ReadAttributeInteger("LastUpdated")){
-						$this->WriteAttributeInteger("LastUpdated", strtotime($Payload->lastupdated." UTC"));
+					$ts = $this->timestampWithMillis($Payload->lastupdated);
+					IPS_LogMessage("millis1", $ts);
+					IPS_LogMessage("millis2", $this->ReadAttributeFloat("LastUpdated"));
+					IPS_LogMessage("millis1 - 30 > millis2", $ts - 0.03 > $this->ReadAttributeFloat("LastUpdated"));
+					if($ts - 0.03 > $this->ReadAttributeFloat("LastUpdated")) {
+						$this->WriteAttributeFloat("LastUpdated", $ts);
 					}else{
 						$update = false;
 					}
@@ -420,4 +424,13 @@ trait DeconzBaseModule
 		}
 		$this->WriteAttributeString('CommandList', json_encode($CommandList));
 	}
+
+
+#=====================================================================================
+protected function timestampWithMillis($isoTime)
+#=====================================================================================
+    {
+        $dt = DateTime::createFromFormat("Y-m-d\TH:i:s.u+", $isoTime);
+        return $dt->getTimestamp() + ($dt->format("u") / 1000000);
+    }	
 }

--- a/libs/DeconzBaseModule.php
+++ b/libs/DeconzBaseModule.php
@@ -17,7 +17,7 @@ trait DeconzBaseModule
         $this->RegisterPropertyString('DeviceID', "");
 #	-----------------------------------------------------------------------------------
 		$this->RegisterAttributeString('CommandList', "");
-		$this->RegisterAttributeInteger("LastUpdated", 0);
+		$this->RegisterAttributeFloat("LastUpdated", 0);
 }
 
 #=====================================================================================

--- a/libs/DeconzBaseModule.php
+++ b/libs/DeconzBaseModule.php
@@ -424,7 +424,7 @@ trait DeconzBaseModule
 
 
 #=====================================================================================
-protected function timestampWithMillis($isoTime)
+	protected function timestampWithMillis($isoTime)
 #=====================================================================================
     {
         $dt = DateTime::createFromFormat("Y-m-d\TH:i:s.u+", $isoTime);

--- a/libs/DeconzBaseModule.php
+++ b/libs/DeconzBaseModule.php
@@ -159,9 +159,7 @@ trait DeconzBaseModule
 				$update = true;
 				if (property_exists($Payload, 'lastupdated')) {
 					$ts = $this->timestampWithMillis($Payload->lastupdated);
-					IPS_LogMessage("millis1", $ts);
-					IPS_LogMessage("millis2", $this->ReadAttributeFloat("LastUpdated"));
-					IPS_LogMessage("millis1 - 30 > millis2", $ts - 0.03 > $this->ReadAttributeFloat("LastUpdated"));
+					IPS_LogMessage("deconz", $ts . " - 0-03 > " $this->ReadAttributeFloat("LastUpdated") " = " . $ts - 0.03 > $this->ReadAttributeFloat("LastUpdated"));
 					if($ts - 0.03 > $this->ReadAttributeFloat("LastUpdated")) {
 						$this->WriteAttributeFloat("LastUpdated", $ts);
 					}else{

--- a/libs/DeconzBaseModule.php
+++ b/libs/DeconzBaseModule.php
@@ -159,7 +159,7 @@ trait DeconzBaseModule
 				$update = true;
 				if (property_exists($Payload, 'lastupdated')) {
 					$ts = $this->timestampWithMillis($Payload->lastupdated);
-					IPS_LogMessage("deconz", $ts . " - 0-03 > " $this->ReadAttributeFloat("LastUpdated") " = " . $ts - 0.03 > $this->ReadAttributeFloat("LastUpdated"));
+					IPS_LogMessage("deconz", $ts . " - 0-03 > " . $this->ReadAttributeFloat("LastUpdated") . " = " . ($ts - 0.03 > $this->ReadAttributeFloat("LastUpdated")));
 					if($ts - 0.03 > $this->ReadAttributeFloat("LastUpdated")) {
 						$this->WriteAttributeFloat("LastUpdated", $ts);
 					}else{

--- a/libs/DeconzHelper.php
+++ b/libs/DeconzHelper.php
@@ -550,5 +550,6 @@ public function SwitchAlert(int $value)
 
         return $dec;
     }
+
 }
 


### PR DESCRIPTION
The problem was that ```strtotime``` does not keep milliseconds and a comparison could mean 10ms or upto 1s.
With this change the ```lastUpdated``` attribute can hold the milliseconds as well and the comparison is against 30ms, which should suffice for debouncing button clicks.

With this fix the IKEA Symfonisk controller can be used to increase/decrease the volume (or whatever you want to steer).
The way it works is by receiving a _gehalten_ when you start turning, and a _losgelassen nach gehalten_ when you stop (often only 200ms), and you need to get both events or you probably will increase the volume forever 🤯 .
